### PR TITLE
feat: change posture for folding and unfolding

### DIFF
--- a/src/android.ts
+++ b/src/android.ts
@@ -3,7 +3,7 @@ import { execFileSync } from "child_process";
 
 import * as xml from "fast-xml-parser";
 
-import { ActionableError, Button, InstalledApp, Robot, ScreenElement, ScreenElementRect, ScreenSize, SwipeDirection, Orientation } from "./robot";
+import { ActionableError, Button, InstalledApp, Robot, ScreenElement, ScreenElementRect, ScreenSize, SwipeDirection, Orientation, PostureStates } from "./robot";
 
 export interface AndroidDevice {
 	deviceId: string;
@@ -316,6 +316,19 @@ export class AndroidRobot implements Robot {
 	public async getOrientation(): Promise<Orientation> {
 		const rotation = this.adb("shell", "settings", "get", "system", "user_rotation").toString().trim();
 		return rotation === "0" ? "portrait" : "landscape";
+	}
+
+	public async changeDevicePosture(posture: PostureStates): Promise<void> {
+		switch (posture) {
+			case "fold": {
+				this.adb("emu", "fold");
+				break;
+			}
+			case "unfold": {
+				this.adb("emu", "unfold");
+				break;
+			}
+		}
 	}
 
 	private async getUiAutomatorDump(): Promise<string> {

--- a/src/ios.ts
+++ b/src/ios.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "child_process";
 import { Socket } from "net";
 
 import { WebDriverAgent } from "./webdriver-agent";
-import { ActionableError, Button, InstalledApp, Robot, ScreenSize, SwipeDirection, ScreenElement, Orientation } from "./robot";
+import { ActionableError, Button, InstalledApp, Robot, ScreenSize, SwipeDirection, ScreenElement, Orientation, PostureStates } from "./robot";
 
 const WDA_PORT = 8100;
 const IOS_TUNNEL_PORT = 60105;
@@ -194,6 +194,10 @@ export class IosRobot implements Robot {
 	public async getOrientation(): Promise<Orientation> {
 		const wda = await this.wda();
 		return await wda.getOrientation();
+	}
+
+	public async changeDevicePosture(posture: PostureStates): Promise<void> {
+		throw new ActionableError("Posture changing is not supported for iOS");
 	}
 }
 

--- a/src/iphone-simulator.ts
+++ b/src/iphone-simulator.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "child_process";
 
 import { WebDriverAgent } from "./webdriver-agent";
-import { ActionableError, Button, InstalledApp, Robot, ScreenElement, ScreenSize, SwipeDirection, Orientation } from "./robot";
+import { ActionableError, Button, InstalledApp, Robot, ScreenElement, ScreenSize, SwipeDirection, Orientation, PostureStates } from "./robot";
 
 export interface Simulator {
 	name: string;
@@ -133,6 +133,10 @@ export class Simctl implements Robot {
 	public async getOrientation(): Promise<Orientation> {
 		const wda = await this.wda();
 		return wda.getOrientation();
+	}
+
+	public async changeDevicePosture(posture: PostureStates): Promise<void> {
+		throw new ActionableError("Posture changing is not supported for iOS");
 	}
 }
 

--- a/src/robot.ts
+++ b/src/robot.ts
@@ -44,6 +44,8 @@ export class ActionableError extends Error {
 
 export type Orientation = "portrait" | "landscape";
 
+export type PostureStates = "fold" | "unfold";
+
 export interface Robot {
 	/**
 	 * Get the screen size of the device in pixels.
@@ -120,4 +122,9 @@ export interface Robot {
 	 * Get the current screen orientation.
 	 */
 	getOrientation(): Promise<Orientation>;
+
+	/**
+	 * Fold or unfold a device. Possible actions: (fold, unfold)
+	 */
+	changeDevicePosture(posture: PostureStates): Promise<void>;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -474,6 +474,19 @@ export const createMcpServer = (): McpServer => {
 		}
 	);
 
+	tool(
+		"mobile_change_posture",
+		"Fold or unfold the device.",
+		{
+			posture: z.enum(["fold", "unfold"]).describe("The desired posture")
+		},
+		async ({ posture }) => {
+			requireRobot();
+			await robot!.changeDevicePosture(posture);
+			return `Changed device posture to ${posture}`;
+		}
+	);
+
 	// async check for latest agent version
 	checkForLatestAgentVersion().then();
 


### PR DESCRIPTION
This pull request introduces support for changing the posture of mobile devices (e.g., folding and unfolding) in the codebase. It adds a new `PostureStates` type, updates relevant interfaces and classes to include posture-changing functionality, and implements this feature for Android devices while providing a placeholder for unsupported iOS devices.

### Feature Addition: Device Posture Management

* [`src/robot.ts`](diffhunk://#diff-926d08284d6805f3927439e29cf6cd4c7594a8654c121c93eac321e5266fcd7eR47-R48): Added a new `PostureStates` type (`"fold"` | `"unfold"`) and updated the `Robot` interface to include a `changeDevicePosture` method for managing device posture. [[1]](diffhunk://#diff-926d08284d6805f3927439e29cf6cd4c7594a8654c121c93eac321e5266fcd7eR47-R48) [[2]](diffhunk://#diff-926d08284d6805f3927439e29cf6cd4c7594a8654c121c93eac321e5266fcd7eR125-R129)

### Android Implementation

* [`src/android.ts`](diffhunk://#diff-34632e78f038aee01b56eebd9e73483544c8127003466eb473ca92f91cad74f1R321-R333): Implemented the `changeDevicePosture` method in the `AndroidRobot` class to handle posture changes using ADB commands (`"emu fold"` and `"emu unfold"`).

### iOS Placeholder

* `src/ios.ts` and `src/iphone-simulator.ts`: Added the `changeDevicePosture` method to the `IosRobot` and `Simctl` classes, but threw an `ActionableError` indicating that posture changes are not supported for iOS devices. [[1]](diffhunk://#diff-7fb9a74aeb61da25b5931036e1c585f9ce46324b0a24100ebc2faa4a9a326766R198-R201) [[2]](diffhunk://#diff-e15846d9369b6477b814f46b3b8eee81216d8df81276ea993b5c3cca067c4fe4R137-R140)

### Server Integration

* [`src/server.ts`](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R477-R489): Added a new server tool command, `mobile_change_posture`, to allow users to fold or unfold a device via the server interface. This command validates the posture input and invokes the `changeDevicePosture` method.